### PR TITLE
Update divumwx.py

### DIFF
--- a/user/divumwx.py
+++ b/user/divumwx.py
@@ -3327,7 +3327,7 @@ class LoopProcessor:
             remote_root = os.path.join(remote_dir, filename),
             server=remote_server,
             user=remote_user,
-            port=str(remote_port) if remote_port is not None else None,
+            port=int(remote_port) if remote_port is not None else None,
             ssh_options=ssh_options,
             compress=compress,
             delete=False,


### PR DESCRIPTION
Corrected port=str(remote_port) to port=(remote_port) on line 3330 to fix the rsync issue, as reported by Chris.