### PR TITLE
added lightning fields to cache exclude list

### DIFF
--- a/archsetup_py.conf
+++ b/archsetup_py.conf
@@ -190,7 +190,7 @@
 'DivumWXRealTime' : {
                 'realtime_path_only':'',
 		'unit_system':'METRICWX',
-		'exclude_fields':'rain,lightningcount,lightning_strike_count,lightning_last_det_time,lightning_distance',
+		'exclude_fields':'rain,lightningcount,lightning_strike_count,lightning_last_det_time',
 		'cache_enable':'True',
 		'cache_stale_time':'900',
                 'weewx_port':'25252',

--- a/macos.conf
+++ b/macos.conf
@@ -190,7 +190,7 @@
 'DivumWXRealTime' : {
                 'realtime_path_only':'',
 		'unit_system':'METRICWX',
-		'exclude_fields':'rain,lightningcount,lightning_strike_count,lightning_last_det_time,lightning_distance',
+		'exclude_fields':'rain,lightningcount,lightning_strike_count,lightning_last_det_time',
 		'cache_enable':'True',
 		'cache_stale_time':'900',
                 'weewx_port':'25252',

--- a/packaged.conf
+++ b/packaged.conf
@@ -190,7 +190,7 @@
 'DivumWXRealTime' : {
                 'realtime_path_only':'',
 		'unit_system':'METRICWX',
-		'exclude_fields':'rain,lightningcount,lightning_strike_count,lightning_last_det_time,lightning_distance',
+		'exclude_fields':'rain,lightningcount,lightning_strike_count,lightning_last_det_time',
 		'cache_enable':'True',
 		'cache_stale_time':'900',
                 'weewx_port':'25252',

--- a/setup_py.conf
+++ b/setup_py.conf
@@ -190,7 +190,7 @@
 'DivumWXRealTime' : {
                 'realtime_path_only':'',
 		'unit_system':'METRICWX',
-		'exclude_fields':'rain,lightningcount,lightning_strike_count,lightning_last_det_time,lightning_distance',
+		'exclude_fields':'rain,lightningcount,lightning_strike_count,lightning_last_det_time',
 		'cache_enable':'True',
 		'cache_stale_time':'900',
                 'weewx_port':'25252',


### PR DESCRIPTION
added lightning fields to cache exclude list to resolve an issue where lightning strikes were being added together at each poll which could be every 2 seconds in some instances.