### PR TITLE
Air Quality Variable name change

### DIFF
--- a/www/dvmAirqualityModule.php
+++ b/www/dvmAirqualityModule.php
@@ -1,13 +1,13 @@
 <?php
 include('dvmCombinedData.php');
 $airqual["pm_units"] = "μg/㎥";
-$airqual["source"] = "weewx";
+$$aqSource = "weewx";
 //PM10 is particulate matter 10 micrometers or less in diameter, PM25 is particulate matter 2.5 micrometers or less in diameter.
 //PM2.5 is generally described as fine particles. By way of comparison, a human hair is about 100 micrometres, so roughly
 //40 fine particles could be placed on its width.
 
 //PurpleAir Sensor source
-if ($airqual["source"] == "purple") {
+if ($$aqSource == "purple") {
 $json_string = file_get_contents("jsondata/pu.txt");
 $parsed_json = json_decode($json_string, true);
 $airqual["pm25"] = $parsed_json["sensor"]["stats"]["pm2.5_24hour"];
@@ -15,13 +15,13 @@ $airqual["pm10"] = $parsed_json["sensor"]["pm10.0"];
 $airqual["city"] = $parsed_json["sensor"]["name"].$airqual["subtitle"];
 }
 //WSeeWX Source
-else if ($airqual["source"] == "weewx") {
+else if ($$aqSource == "weewx") {
 $airqual["pm25"] = $air["24h.rollingavg.pm2_5"];
 $airqual["pm10"] = $air["24h.rollingavg.pm10_0"];
 $airqual["city"] = $stationlocation.$airqual["subtitle"];
 }
 //WAQI Source
-else if ($airqual["source"] == "waqi") {
+else if ($$aqSource == "waqi") {
 $json_string = file_get_contents("jsondata/aq.txt");
 $parsed_json = json_decode($json_string, true);
 $airqual["pm25"] = $parsed_json["data"]["iaqi"]["pm25"]["v"];
@@ -29,7 +29,7 @@ $airqual["pm10"] = $parsed_json["data"]["iaqi"]["pm10"]["v"];
 $airqual["city"] = $parsed["data"]["city"]["name"].$airqual["subtitle"];
 }
 //SDS Source
-else if ($airqual["source"] == "sds"){
+else if ($$aqSource == "sds"){
 $json_string = file_get_contents("jsondata/aqiJson.txt");
 $parsed_json = json_decode($json_string, true);
 $airqual["pm25"] = round($parsed_json['pm25'],1);
@@ -38,7 +38,7 @@ $airqual["city"] = $stationlocation.$airqual["subtitle"];
 }
 
 //Europe EAQI
-if ($airqual["zone"] == "ei"){
+if ($$aqZone == "ei"){
 	if ($airqual["pm25"] < 11 ){
 		$airqual["image25"] = "./css/aqi/goodair.svg?ver=1.4";
 		$airqual["color25"] = "#51F0E6";
@@ -112,7 +112,7 @@ if ($airqual["zone"] == "ei"){
 }
 
 //Europe CAQI
-if ($airqual["zone"] == "ci"){
+if ($$aqZone == "ci"){
 	if ($airqual["pm25"] < 16 ){
 		$airqual["image25"] = "./css/aqi/goodair.svg?ver=1.4";
 		$airqual["color25"] = "#7ABC6A";
@@ -180,7 +180,7 @@ if ($airqual["zone"] == "ci"){
 }
 
 //UK AQI
-if ($airqual["zone"] == "uk"){
+if ($$aqZone == "uk"){
 	if ($airqual["pm25"] < 12 ){
 		$airqual["image25"] = "./css/aqi/goodair.svg?ver=1.4";
 		$airqual["color25"] = "#CCFFCC";
@@ -325,7 +325,7 @@ if ($airqual["zone"] == "uk"){
 }
 
 //USA & WAQI
-if ($airqual["zone"] == "us"){
+if ($$aqZone == "us"){
 
 function pm25_to_aqi($pm25){
 	if ($pm25 > 500.5) {
@@ -468,7 +468,7 @@ if ($airqual["aqi10"] < 55 ){
 }
 
 //Australia AQI
-if ($airqual["zone"] == "au"){
+if ($$aqZone == "au"){
 	$airqual["aqi25"] = round($airqual["pm25"]*4, 0);
 	if ($airqual["aqi25"] < 34 ){
 		$airqual["image25"] = "./css/aqi/goodair.svg?ver=1.4";

--- a/www/dvmAirqualityTop.php
+++ b/www/dvmAirqualityTop.php
@@ -5,24 +5,24 @@ include('dvmCombinedData.php');
 $airqual["pm_units"] = "μg/㎥";
 
 
-if ($airqual["source"] == "purple") {
+if ($aqSource == "purple") {
 $json_string = file_get_contents("jsondata/pu.txt");
 $parsed_json = json_decode($json_string, true);
 $airqual["pm25"] = $parsed_json["sensor"]["stats"]["pm2.5"];
 $airqual["city"] = $parsed_json["sensor"]["name"];
 
 }
-else if ($airqual["source"] == "weewx") {
+else if ($aqSource == "weewx") {
 $airqual["pm25"] = $air["current.pm2_5"];
 $airqual["city"] = $stationlocation;
 }
-else if ($airqual["source"] == "waqi") {
+else if ($aqSource == "waqi") {
 $json_string = file_get_contents("jsondata/aq.txt");
 $parsed_json = json_decode($json_string, true);
 $airqual["pm25"] = $parsed_json['data']['iaqi']['pm25']['v'];
 $airqual["city"] = $parsed["data"]["city"]["name"];
 }
-else if ($airqual["source"] == "sds"){
+else if ($aqSource == "sds"){
 $json_string = file_get_contents("jsondata/aqiJson.txt");
 $parsed_json = json_decode($json_string, true);
 $airqual["pm25"] = round($parsed_json['pm25'],1);
@@ -30,7 +30,7 @@ $airqual["city"] = $stationlocation;
 }
 
 //Europe EAQI
-if ($airqual["zone"] == "ei"){
+if ($aqZone == "ei"){
  
 if ($airqual["pm25"] < 11 ){
 $airqual["image25"] = "./css/aqi/goodair.svg?ver=1.4";
@@ -68,7 +68,7 @@ $airqual["text"] = "Extremely Poor Air Quality";
 }
 
 //Europe CAQI
-if ($airqual["zone"] == "ci"){
+if ($aqZone == "ci"){
  
 if ($airqual["pm25"] < 16 ){
 $airqual["image25"] = "./css/aqi/goodair.svg?ver=1.4";
@@ -105,7 +105,7 @@ $airqual["text"] = "Very High Air Pollution";
 }
 
 //UK
-if ($airqual["zone"] == "uk"){
+if ($aqZone == "uk"){
 
 if ($airqual["pm25"] < 12 ){
 $airqual["image25"] = "./css/aqi/goodair.svg?ver=1.4";
@@ -171,7 +171,7 @@ $airqual["text"] = "Very High Pollution";
 }
 
 //USA & WAQI
-if ($airqual["zone"] == "us"){
+if ($aqZone == "us"){
 
 function pm25_to_aqi($pm25){
 	if ($pm25 > 500.5) {
@@ -253,7 +253,7 @@ $airqual["text"] = "Hazardous Air Quality";
 }
 
 //Australia
-if ($airqual["zone"] == "au"){
+if ($aqZone == "au"){
 $airqual["aqi25"] = round($airqual["pm25"]*4, 0);
 if ($airqual["aqi25"] < 34 ){
 $airqual["image25"] = "./css/aqi/goodair.svg?ver=1.4";

--- a/www/dvmHomeIndoorPopup.php
+++ b/www/dvmHomeIndoorPopup.php
@@ -157,7 +157,7 @@ else if($temp["indoor_now_feels"] <=18)echo "<div class='divumwxindoormild'>Mild
 
 <?php 
 
-if($airqual["in_use"]== 'yes'){?>
+if($aqInUse == 'yes'){?>
 <article> 
    <div class=actualt>Air Quality</div>        
    

--- a/www/dvmVersion.php
+++ b/www/dvmVersion.php
@@ -1,3 +1,3 @@
 <?php
-$templateversion = "DVM-<maxblue>Alpha build 0.6.5</maxblue>";
+$templateversion = "DVM-<maxblue>Alpha build 0.6.6</maxblue>";
 ?>

--- a/www/fixedSettings.php
+++ b/www/fixedSettings.php
@@ -187,20 +187,20 @@ else if ($advisoryzone == "na") {
     $advisory = "dvmAdvisoryNaPopup.php";
 }
 
-if ($airqual["zone"] == "uk") {
+if ($aqZone == "uk") {
     $airqual["subtitle"] = " - UK DAQI";
 }
-else if ($airqual["zone"] == "ei") {
+else if ($aqZone == "ei") {
     $airqual["subtitle"] = " - Europe EAQI";
 }
 
-else if ($airqual["zone"] == "ci") {
+else if ($aqZone == "ci") {
     $airqual["subtitle"] = " - Europe CAQI";
 }
-else if ($airqual["zone"] == "au") {
+else if ($aqZone == "au") {
     $airqual["subtitle"] = " - Australian AQI";
 } 
-else if ($airqual["zone"] == "us") {
+else if ($aqZone == "us") {
     $airqual["subtitle"] = " - USA EPA";
 }
 

--- a/www/initial_userSettings.php
+++ b/www/initial_userSettings.php
@@ -8,9 +8,9 @@ $timeFormat = "H:i:s"; //g:i:s, g:i:s a
 $timeFormatShort = "H:i"; //g:i, g:i a
 $clockformat = "24"; //12, 24
 $advisoryzone = "uk"; //uk, na, eu, au, rw (= UK, North America, Europe, Australia, Rest of World)
-$airqual["in_use"] = "yes"; // yes, no
-$airqual["zone"] = "uk"; //uk, us, ei, ci, au, (= UK DAQI, US EPS, Europe EAQI, Europe CAQI, Australia)
-$airqual["source"] = "weewx";  //purple, weewx, sds
+$aqInUse = "yes"; // yes, no
+$aqZone = "uk";//uk, us, ei, ci, au, (= UK DAQI, US EPS, Europe EAQI, Europe CAQI, Australia)
+$aqSource = "weewx"; //purple, weewx, sds
 $lightningSource = 1; // 0 = Boltek, 1 = all
 $position2 = "dvmAirqualityTop.php";
 $position3 = "dvmLightningTop.php";


### PR DESCRIPTION
Changed the following variables: $airqual["in_use"], $airqual["zone"] and $airqual["source"] to $aqInUse, $aqZone and $aqSource as the original variables were stored in an array inside a variable which was playing havoc with the Admin Settings editor and building looping functions to check for changes. There is no reason to have stored those variables inside an array.

NOTE:  This change requires existing users to modify their userSettings.php file and replace the following lines:

$airqual["in_use"] = "yes"; // yes, no
$airqual["zone"] = "uk"; //uk, us, ei, ci, au, (= UK DAQI, US EPS, Europe EAQI, Europe CAQI, Australia)
$airqual["source"] = "weewx";  //purple, weewx, sds

With

$aqInUse = "yes"; // yes, no
$aqZone = "uk";//uk, us, ei, ci, au, (= UK DAQI, US EPS, Europe EAQI, Europe CAQI, Australia)
$aqSource = "weewx"; //purple, weewx, sds