### PR TITLE
Remove time from "Operational Since" in footer to improve formatting

### DIFF
--- a/skins/DivumWX/dvmCombinedData.php.tmpl
+++ b/skins/DivumWX/dvmCombinedData.php.tmpl
@@ -99,7 +99,7 @@ $divum["date"] = date($dateFormat, $divum["datetime"]);
 $divum["time"] = date($timeFormat, $divum["datetime"]);
 $divum["swversion"] = "$station.version";
 $divum["build"] = $weewxrt[38];
-$divum["since"] = "$alltime.outTemp.firsttime.format("%d %b %Y %H:%M")";
+$divum["since"] = date('D M Y',$alltime.outTemp.firsttime.raw);
 $stationUptime = "$station.uptime.long_form";
 
 //almanac


### PR DESCRIPTION
Remove time from "Operational Since" in footer to improve formatting

Change made by Sean I am just submitting it. :)