### PR TITLE
Adjust format of footer

### DIFF
--- a/skins/DivumWX/dvmCombinedData.php.tmpl
+++ b/skins/DivumWX/dvmCombinedData.php.tmpl
@@ -99,7 +99,7 @@ $divum["date"] = date($dateFormat, $divum["datetime"]);
 $divum["time"] = date($timeFormat, $divum["datetime"]);
 $divum["swversion"] = "$station.version";
 $divum["build"] = $weewxrt[38];
-$divum["since"] = "$alltime.outTemp.firsttime.format("%d %b %Y %H:%M")";
+$divum["since"] = "$alltime.outTemp.firsttime.raw;
 $stationUptime = "$station.uptime.long_form";
 
 //almanac

--- a/www/dvmFooter.php
+++ b/www/dvmFooter.php
@@ -20,7 +20,7 @@
         <?php echo '<a href="https://https://claydonsweather.org.uk/" title="https://claydonsweather.org.uk/" target="_blank"><br><img src="img/divumLogo.svg" width="40px" alt="https://https://claydonsweather.org.uk/" class="homeweatherstationlogo" ><divumwx>Copyright &copy; 2022-' . date('Y') . '<br>Team DivumWX<br>All rights reserved</divumwx></a>';?>
       </div>
       <div class="footertext"><red><?php echo "Never base important decisions that could result in harm to people or property on this weather information." ?></red></div>
-      <div class="footertext"><?php echo "Operational Since " . $divum["since"]." - "; $info;?> (<value><?php echo $templateversion;?></value>) <?php echo " - WeeWX";?>-(<value><maxred><?php echo $divum["swversion"];?></value>)  - OS- <yellow><?php echo " " . $weatherhardware . "". $os_version;?></value></div>
+      <div class="footertext"><?php echo "Operational Since " . date("j M Y",$divum["since"])." - "; $info;?> (<value><?php echo $templateversion;?></value>) <?php echo " - WeeWX";?>-(<value><maxred><?php echo $divum["swversion"];?></value>)  - OS- <yellow><?php echo " " . $weatherhardware . "". $os_version;?></value></div>
       <div class="footertext"><a href="https://www.aerisweather.com/"><img src="img/aerisweather-attribution-h-<?php echo $theme;?>.png" width="75px"></a><br /><a href="https://developer.yr.no/featured-products/forecast/">    Meteogram Data by <img src="img/yr.svg" width="14px"></a><br /><a href="https://bas.dev/work/meteocons">     Animated Icons by <img src="img/bm.svg" width="14px"></a>
     </div>
   </div>


### PR DESCRIPTION
Changed .tmpl output of date since to raw timestamp. Date now formated in dvmFooter.php to give flexibility.

This an alternative solution to the one proposed by @gitty85 which moves the formatting from .tmpl to  dvmFooter.php. This makes it more flexible if other users may wish have alternative date formats.